### PR TITLE
Feat: Speicherung der API-Keys via Env-Variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+TEST=testvalue

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ The following requirements must be met:
 To launch the application, perform the following steps:
 
 1. clone repository
-2. duplicate the `.env.example` file and rename it to `.env` (Bash-Befehl: `cp .env.example
-   .env`)
+2. duplicate the `.env.example` file and rename it to `.env` (Bash-Befehl:
+   `cp .env.example .env`)
 3. fill in the missing values in the `.env` file
 4. run `docker compose up --build` in the root directory of the project
 5. close the application with `CTRL + C`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 im Rahmen des Moduls
 
-Projekt 2\
+**Projekt 2**\
 im Medieninformatik Master\
 Schwerpunkt Human-Computer Interaction\
 Technische Hochschule Köln\
@@ -24,13 +24,13 @@ Each Service has a runtime of Deno. They all share the same deno.json and
 import_map.json files, which are loaded into the container at runtime. The
 following ports are used:
 
-- ChallengeAPI: 3000
-- ChallengeAPI-Database: 3307
-- DisturbanceAPI: 3001
-- DisturbanceAPI-Database: 3308
-- RouteAPI: 3002
-- RouteAPI-Database: 3306
-- MQTT-Broker: 1883
+- ChallengeAPI: `3000`
+- ChallengeAPI-Database: `3307`
+- DisturbanceAPI: `3001`
+- DisturbanceAPI-Database: `3308`
+- RouteAPI: `3002`
+- RouteAPI-Database: `3306`
+- MQTT-Broker: `1883`
 
 ## Installation
 
@@ -42,8 +42,11 @@ The following requirements must be met:
 To launch the application, perform the following steps:
 
 1. clone repository
-2. run `docker compose up --build` in the root directory of the project
-3. close the application with `CTRL + C`
+2. duplicate the `.env.example` file and rename it to `.env` (Bash-Befehl: `cp .env.example
+   .env`)
+3. fill in the missing values in the `.env` file
+4. run `docker compose up --build` in the root directory of the project
+5. close the application with `CTRL + C`
 
 ## Contributing
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
       - DB_PORT=3306
       - DB_USER=root
       - DB_PASSWORD=password
+    env_file: .env
 
   challenge-api-db:
     image: mariadb:10.11
@@ -62,6 +63,7 @@ services:
       - DB_PORT=3306
       - DB_USER=root
       - DB_PASSWORD=password
+    env_file: .env
 
   disturbance-api-db:
     image: mariadb:10.11
@@ -98,6 +100,7 @@ services:
       - DB_PORT=3306
       - DB_USER=root
       - DB_PASSWORD=password
+    env_file: .env
 
   route-api-db:
     image: mariadb:10.11


### PR DESCRIPTION
Closes #18 

This PR...

- implements a way to introduce ENV-Variables that are accessible in the runtime via Deno and are not tracked in git
- updated README to introduce new setup step